### PR TITLE
UI: Remove hint showing format of Registration Period

### DIFF
--- a/app/src/main/res/layout/activity_organizer_create_event.xml
+++ b/app/src/main/res/layout/activity_organizer_create_event.xml
@@ -144,7 +144,6 @@
                     android:id="@+id/et_registration_period"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="e.g. 2024-10-01 to 2024-10-31"
                     android:inputType="text" />
             </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/activity_organizer_edit_event.xml
+++ b/app/src/main/res/layout/activity_organizer_edit_event.xml
@@ -144,7 +144,6 @@
                     android:id="@+id/et_registration_period"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="e.g. 2024-10-01 to 2024-10-31"
                     android:inputType="text" />
             </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
This pull request makes a minor UI adjustment by removing the example hint text from the registration period input fields in both the event creation and event editing screens.

* Removed the hint "e.g. 2024-10-01 to 2024-10-31" from the `et_registration_period` input in `activity_organizer_create_event.xml` and `activity_organizer_edit_event.xml` to simplify the UI. [[1]](diffhunk://#diff-37fb9da490ccfc6c6bc726419fa1d999349e61038aba2b69901d842e7ed150ccL147) [[2]](diffhunk://#diff-ec9318c98263572e48832a9718ade350b368f5b408677058745cff8cca288b55L147)