### PR TITLE
Hide registration period format and update organizer flow tests

### DIFF
--- a/app/src/androidTest/java/com/example/wecookproject/OrganizerFlowTest.java
+++ b/app/src/androidTest/java/com/example/wecookproject/OrganizerFlowTest.java
@@ -192,20 +192,9 @@ public class OrganizerFlowTest {
         notifScenario.close();
     }
 
-    /**
-     * Drives the full signup happy-path:
-     *   LoginActivity → SignupDetailsActivity → SignupAddressActivity → MainActivity
-     *
-     * Call this at the start of any test that needs an existing Firestore user
-     * (i.e., the device must already be "signed up") before jumping into
-     * organizer-specific screens.
-     *
-     * Note: @Before deletes the Firestore user and launches LoginActivity, so
-     * the activityScenario is already open when this helper is called.
-     */
     private void performFullSignup() {
         // Login screen
-        onView(withId(R.id.text_Admin_login)).perform(click());
+        onView(withId(R.id.btn_organizer_login)).perform(click());
 
         // Details screen
         safeSleep(1500);
@@ -223,7 +212,7 @@ public class OrganizerFlowTest {
         onView(withId(R.id.et_postal_code)).perform(typeText("T6G 2R3"), closeSoftKeyboard());
         onView(withId(R.id.btn_continue)).perform(click());
 
-        // Wait for Firestore write and navigation to MainActivity
+        // Wait for Firestore write and navigation to OrganizerHomeActivity
         safeSleep(2500);
     }
 

--- a/app/src/main/java/com/example/wecookproject/OrganizerCreateEventActivity.java
+++ b/app/src/main/java/com/example/wecookproject/OrganizerCreateEventActivity.java
@@ -4,12 +4,29 @@ import android.content.Intent;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 
 public class OrganizerCreateEventActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_organizer_create_event);
+
+        TextInputEditText etRegistrationPeriod = findViewById(R.id.et_registration_period);
+        TextInputLayout tilRegistrationPeriod = findViewById(R.id.til_registration_period);
+
+        etRegistrationPeriod.setOnFocusChangeListener((v, hasFocus) -> {
+            if (hasFocus) {
+                tilRegistrationPeriod.setHint("Registration Period");
+            } else {
+                if (etRegistrationPeriod.getText() != null && etRegistrationPeriod.getText().toString().isEmpty()) {
+                    tilRegistrationPeriod.setHint("Registration Period (YYYY-MM-DD)");
+                } else {
+                    tilRegistrationPeriod.setHint("Registration Period");
+                }
+            }
+        });
 
         BottomNavigationView bottomNav = findViewById(R.id.bottom_nav);
         bottomNav.setSelectedItemId(R.id.nav_create_events);

--- a/app/src/main/java/com/example/wecookproject/OrganizerEditEventActivity.java
+++ b/app/src/main/java/com/example/wecookproject/OrganizerEditEventActivity.java
@@ -4,12 +4,29 @@ import android.content.Intent;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 
 public class OrganizerEditEventActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_organizer_edit_event);
+
+        TextInputEditText etRegistrationPeriod = findViewById(R.id.et_registration_period);
+        TextInputLayout tilRegistrationPeriod = findViewById(R.id.til_registration_period);
+
+        etRegistrationPeriod.setOnFocusChangeListener((v, hasFocus) -> {
+            if (hasFocus) {
+                tilRegistrationPeriod.setHint("Registration Period");
+            } else {
+                if (etRegistrationPeriod.getText() != null && etRegistrationPeriod.getText().toString().isEmpty()) {
+                    tilRegistrationPeriod.setHint("Registration Period (YYYY-MM-DD)");
+                } else {
+                    tilRegistrationPeriod.setHint("Registration Period");
+                }
+            }
+        });
 
         BottomNavigationView bottomNav = findViewById(R.id.bottom_nav);
         bottomNav.setOnItemSelectedListener(item -> {

--- a/app/src/main/res/layout/activity_organizer_create_event.xml
+++ b/app/src/main/res/layout/activity_organizer_create_event.xml
@@ -139,7 +139,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:hint="Registration Period">
+                android:hint="Registration Period (YYYY-MM-DD)">
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/et_registration_period"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_organizer_edit_event.xml
+++ b/app/src/main/res/layout/activity_organizer_edit_event.xml
@@ -139,7 +139,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:hint="Registration Period">
+                android:hint="Registration Period (YYYY-MM-DD)">
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/et_registration_period"
                     android:layout_width="match_parent"


### PR DESCRIPTION
This pull request introduces improvements to the registration period input field for both event creation and editing screens, as well as minor updates to the organizer signup flow. The main focus is on enhancing user guidance for date input and improving the hint behavior in the UI.

**Registration Period Input Improvements:**

* Added dynamic hint behavior for the `et_registration_period` field in both `OrganizerCreateEventActivity` and `OrganizerEditEventActivity`, so the hint changes based on focus and whether the field is empty. This guides users to enter the date in the correct format. [[1]](diffhunk://#diff-4b7a8147743f0525b928e25acb544b89c36d7260b9acaf30126956658801f855R7-R30) [[2]](diffhunk://#diff-9f585e0a1681206aaa4fcae486f054565ea65a2e0107150602777f81af6ae731R7-R30)
* Updated the static hint in the registration period field in both `activity_organizer_create_event.xml` and `activity_organizer_edit_event.xml` to specify the expected date format (`YYYY-MM-DD`). [[1]](diffhunk://#diff-37fb9da490ccfc6c6bc726419fa1d999349e61038aba2b69901d842e7ed150ccL142-R142) [[2]](diffhunk://#diff-ec9318c98263572e48832a9718ade350b368f5b408677058745cff8cca288b55L142-R142)

**Organizer Signup Flow Adjustments:**

* Modified the organizer login button reference in the test helper method `performFullSignup` to use `btn_organizer_login` instead of `text_Admin_login`, ensuring the test reflects the current UI.
* Updated the comment in `performFullSignup` to clarify that navigation is to `OrganizerHomeActivity` after signup, not just `MainActivity`.