### PR TITLE
Add mandatory waitlist geolocation and organizer registration map

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,4 +47,6 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-firestore")
     implementation("com.google.firebase:firebase-storage")
+    implementation("com.google.android.gms:play-services-location:21.3.0")
+    implementation("com.google.android.gms:play-services-maps:19.2.0")
 }

--- a/app/src/androidTest/java/com/example/wecookproject/OrganizerFlowTest.java
+++ b/app/src/androidTest/java/com/example/wecookproject/OrganizerFlowTest.java
@@ -278,11 +278,11 @@ public class OrganizerFlowTest {
 
     /**
      * test8: Launching OrganizerEventDetailsActivity with a valid event ID
-     * should display all required UI elements (name, dates, edit, waitlist, map
-     * buttons).
+     * should display required UI elements, hide removed geolocation toggle,
+     * and navigate to Registration Map.
      */
     @Test
-    public void test8_EventDetailsScreenDisplaysCorrectly() {
+    public void test8_EventDetailsScreenDisplaysAndNavigatesToRegistrationMap() {
         // Use a unique ID to avoid collisions across test runs
         String mockEventId = "mock-details-" + UUID.randomUUID();
         @SuppressWarnings("deprecation")
@@ -296,7 +296,7 @@ public class OrganizerFlowTest {
                 100,
                 50,
                 "Random",
-                false,
+                true,
                 "Edmonton",
                 "Test description"
         );
@@ -320,6 +320,10 @@ public class OrganizerFlowTest {
         onView(withId(R.id.btn_edit_event)).check(matches(isDisplayed()));
         onView(withId(R.id.btn_view_waitlist)).check(matches(isDisplayed()));
         onView(withId(R.id.btn_registration_map)).check(matches(isDisplayed()));
+
+        onView(withId(R.id.btn_registration_map)).perform(click());
+        safeSleep(WAIT_MEDIUM);
+        onView(withId(R.id.btn_back_to_event)).check(matches(isDisplayed()));
 
         detailsScenario.close();
 
@@ -386,11 +390,9 @@ public class OrganizerFlowTest {
         scenario.close();
     }
 
-    // 鈹€鈹€鈹€ Helpers 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
-
     /**
      * Drives the full organizer signup flow that is launched from LoginActivity
-     * (Details screen 鈫?Address screen) and waits until OrganizerHomeActivity
+     * (Details screen Address screen) and waits until OrganizerHomeActivity
      * is visible.
      */
     private void performFullSignup() {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:allowBackup="true"
@@ -13,6 +15,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Wecookproject">
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="@string/google_maps_key" />
         <activity
             android:name=".UserEventDetailsActivity"
             android:exported="false" />

--- a/app/src/main/java/com/example/wecookproject/OrganizerCreateEventActivity.java
+++ b/app/src/main/java/com/example/wecookproject/OrganizerCreateEventActivity.java
@@ -143,7 +143,7 @@ public class OrganizerCreateEventActivity extends AppCompatActivity {
                     maxWaitlist,
                     0, // currentWaitlistCount starts at 0
                     lotteryMethodology,
-                    false, // Default geolocation
+                    true, // Geolocation is mandatory
                     "Location TBD", // Default location
                     "" // Default description
             );

--- a/app/src/main/java/com/example/wecookproject/OrganizerEventDetailsActivity.java
+++ b/app/src/main/java/com/example/wecookproject/OrganizerEventDetailsActivity.java
@@ -122,7 +122,13 @@ public class OrganizerEventDetailsActivity extends AppCompatActivity {
         });
         
         findViewById(R.id.btn_registration_map).setOnClickListener(v -> {
-             Toast.makeText(this, "Map clicked", Toast.LENGTH_SHORT).show();
+             if (eventId != null) {
+                 Intent intent = new Intent(this, OrganizerEventMapActivity.class);
+                 intent.putExtra("eventId", eventId);
+                 startActivity(intent);
+             } else {
+                 Toast.makeText(this, "No event ID provided", Toast.LENGTH_SHORT).show();
+             }
         });
 
         findViewById(R.id.btn_show_qr).setOnClickListener(v -> {

--- a/app/src/main/java/com/example/wecookproject/OrganizerEventMapActivity.java
+++ b/app/src/main/java/com/example/wecookproject/OrganizerEventMapActivity.java
@@ -2,16 +2,56 @@ package com.example.wecookproject;
 
 import android.content.Intent;
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
-import com.google.android.material.bottomnavigation.BottomNavigationView;
+import android.widget.TextView;
+import android.widget.Toast;
 
-public class OrganizerEventMapActivity extends AppCompatActivity {
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.android.gms.maps.CameraUpdateFactory;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.OnMapReadyCallback;
+import com.google.android.gms.maps.SupportMapFragment;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.MarkerOptions;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.GeoPoint;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class OrganizerEventMapActivity extends AppCompatActivity implements OnMapReadyCallback {
+    private final FirebaseFirestore db = FirebaseFirestore.getInstance();
+    private GoogleMap googleMap;
+    private String eventId;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_organizer_event_map);
 
+        eventId = getIntent().getStringExtra("eventId");
+        if (eventId == null || eventId.trim().isEmpty()) {
+            Toast.makeText(this, "No event ID provided", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
+        SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map_fragment);
+        if (mapFragment != null) {
+            mapFragment.getMapAsync(this);
+        } else {
+            Toast.makeText(this, "Map initialization failed", Toast.LENGTH_SHORT).show();
+        }
+
+        loadEventHeader();
+        loadEntrantLocations();
+
         BottomNavigationView bottomNav = findViewById(R.id.bottom_nav);
+        bottomNav.setSelectedItemId(R.id.nav_events);
         bottomNav.setOnItemSelectedListener(item -> {
             int id = item.getItemId();
             if (id == R.id.nav_events) {
@@ -32,5 +72,112 @@ public class OrganizerEventMapActivity extends AppCompatActivity {
         findViewById(R.id.btn_show_qr).setOnClickListener(v -> {
             // TODO: show QR code dialog
         });
+    }
+
+    @Override
+    public void onMapReady(GoogleMap map) {
+        googleMap = map;
+        googleMap.getUiSettings().setZoomControlsEnabled(true);
+        googleMap.getUiSettings().setMapToolbarEnabled(true);
+        loadEntrantLocations();
+    }
+
+    private void loadEventHeader() {
+        db.collection("events").document(eventId).get()
+                .addOnSuccessListener(snapshot -> {
+                    if (!snapshot.exists()) {
+                        Toast.makeText(this, "Event not found", Toast.LENGTH_SHORT).show();
+                        finish();
+                        return;
+                    }
+
+                    TextView tvEventName = findViewById(R.id.tv_event_name);
+                    TextView tvEventLocation = findViewById(R.id.tv_event_location);
+                    tvEventName.setText(snapshot.getString("eventName"));
+                    String location = snapshot.getString("location");
+                    tvEventLocation.setText(location == null || location.trim().isEmpty() ? "Location TBD" : location);
+                })
+                .addOnFailureListener(e -> Toast.makeText(this, "Failed to load event details", Toast.LENGTH_SHORT).show());
+    }
+
+    private void loadEntrantLocations() {
+        if (googleMap == null) {
+            return;
+        }
+
+        db.collection("events").document(eventId).get()
+                .addOnSuccessListener(snapshot -> {
+                    if (!snapshot.exists()) {
+                        Toast.makeText(this, "Event not found", Toast.LENGTH_SHORT).show();
+                        finish();
+                        return;
+                    }
+
+                    googleMap.clear();
+                    List<MarkerData> markers = extractMarkers(snapshot.get("waitlistEntrantLocations"));
+                    if (markers.isEmpty()) {
+                        Toast.makeText(this, "No waitlist locations yet", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    LatLngBounds.Builder boundsBuilder = new LatLngBounds.Builder();
+                    for (MarkerData marker : markers) {
+                        LatLng latLng = new LatLng(marker.latitude, marker.longitude);
+                        googleMap.addMarker(new MarkerOptions().position(latLng).title(marker.title));
+                        boundsBuilder.include(latLng);
+                    }
+
+                    if (markers.size() == 1) {
+                        MarkerData single = markers.get(0);
+                        googleMap.animateCamera(CameraUpdateFactory.newLatLngZoom(
+                                new LatLng(single.latitude, single.longitude), 13f));
+                    } else {
+                        googleMap.animateCamera(CameraUpdateFactory.newLatLngBounds(boundsBuilder.build(), 120));
+                    }
+                })
+                .addOnFailureListener(e -> Toast.makeText(this, "Failed to load waitlist locations", Toast.LENGTH_SHORT).show());
+    }
+
+    private List<MarkerData> extractMarkers(Object rawLocations) {
+        List<MarkerData> markers = new ArrayList<>();
+        if (!(rawLocations instanceof Map<?, ?>)) {
+            return markers;
+        }
+
+        Map<?, ?> locationsByEntrantId = (Map<?, ?>) rawLocations;
+        for (Map.Entry<?, ?> entry : locationsByEntrantId.entrySet()) {
+            String entrantId = Objects.toString(entry.getKey(), "");
+            Object value = entry.getValue();
+            GeoPoint geoPoint = null;
+
+            if (value instanceof GeoPoint) {
+                geoPoint = (GeoPoint) value;
+            } else if (value instanceof Map<?, ?>) {
+                Map<?, ?> nestedMap = (Map<?, ?>) value;
+                Object latObj = nestedMap.get("lat");
+                Object lngObj = nestedMap.get("lng");
+                if (latObj instanceof Number && lngObj instanceof Number) {
+                    geoPoint = new GeoPoint(((Number) latObj).doubleValue(), ((Number) lngObj).doubleValue());
+                }
+            }
+
+            if (geoPoint != null) {
+                String suffix = entrantId.length() > 6 ? entrantId.substring(entrantId.length() - 6) : entrantId;
+                markers.add(new MarkerData(geoPoint.getLatitude(), geoPoint.getLongitude(), "Entrant " + suffix));
+            }
+        }
+        return markers;
+    }
+
+    private static class MarkerData {
+        private final double latitude;
+        private final double longitude;
+        private final String title;
+
+        private MarkerData(double latitude, double longitude, String title) {
+            this.latitude = latitude;
+            this.longitude = longitude;
+            this.title = title;
+        }
     }
 }

--- a/app/src/main/java/com/example/wecookproject/UserEventActivity.java
+++ b/app/src/main/java/com/example/wecookproject/UserEventActivity.java
@@ -1,9 +1,12 @@
 package com.example.wecookproject;
 
+import android.Manifest;
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
+import android.location.Location;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.view.LayoutInflater;
@@ -15,7 +18,10 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -25,7 +31,12 @@ import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.GeoPoint;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.Priority;
+import com.google.android.gms.tasks.CancellationTokenSource;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,6 +53,10 @@ public class UserEventActivity extends AppCompatActivity {
     private UserEventAdapter eventAdapter;
     private String entrantId;
     private BottomNavigationView bottomNav;
+    private FusedLocationProviderClient fusedLocationClient;
+    private ActivityResultLauncher<String[]> locationPermissionLauncher;
+    private UserEventRecord pendingJoinEventRecord;
+    private AlertDialog pendingJoinDialog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -49,6 +64,19 @@ public class UserEventActivity extends AppCompatActivity {
         setContentView(R.layout.activity_user_event_list);
 
         entrantId = Settings.Secure.getString(getContentResolver(), Settings.Secure.ANDROID_ID);
+        fusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
+        locationPermissionLauncher = registerForActivityResult(
+                new ActivityResultContracts.RequestMultiplePermissions(),
+                result -> {
+                    boolean granted = Boolean.TRUE.equals(result.get(Manifest.permission.ACCESS_FINE_LOCATION))
+                            || Boolean.TRUE.equals(result.get(Manifest.permission.ACCESS_COARSE_LOCATION));
+                    if (granted && pendingJoinEventRecord != null && pendingJoinDialog != null) {
+                        fetchLocationAndJoinWaitlist(pendingJoinEventRecord, pendingJoinDialog);
+                    } else if (!granted) {
+                        Toast.makeText(this, "Location permission is required to join the waitlist", Toast.LENGTH_SHORT).show();
+                    }
+                }
+        );
 
         rvEvents = findViewById(R.id.rv_events);
         tvEmptyState = findViewById(R.id.tv_empty_state);
@@ -260,17 +288,66 @@ public class UserEventActivity extends AppCompatActivity {
         }
 
         btnJoinWaitlist.setText("Join the Waitlist");
-        btnJoinWaitlist.setOnClickListener(v -> joinWaitingList(eventRecord, dialog));
+        btnJoinWaitlist.setOnClickListener(v -> requestLocationAndJoinWaitlist(eventRecord, dialog));
     }
 
-    private void joinWaitingList(UserEventRecord eventRecord, AlertDialog dialog) {
+    private void requestLocationAndJoinWaitlist(UserEventRecord eventRecord, AlertDialog dialog) {
+        pendingJoinEventRecord = eventRecord;
+        pendingJoinDialog = dialog;
+        if (hasLocationPermission()) {
+            fetchLocationAndJoinWaitlist(eventRecord, dialog);
+            return;
+        }
+
+        locationPermissionLauncher.launch(new String[]{
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+        });
+    }
+
+    private void fetchLocationAndJoinWaitlist(UserEventRecord eventRecord, AlertDialog dialog) {
+        if (!hasLocationPermission()) {
+            Toast.makeText(this, "Location permission is required to join the waitlist", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        fusedLocationClient.getLastLocation()
+                .addOnSuccessListener(location -> {
+                    if (location != null) {
+                        joinWaitingList(eventRecord, dialog, location);
+                        return;
+                    }
+
+                    CancellationTokenSource tokenSource = new CancellationTokenSource();
+                    fusedLocationClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, tokenSource.getToken())
+                            .addOnSuccessListener(currentLocation -> {
+                                if (currentLocation == null) {
+                                    Toast.makeText(this, "Unable to read location. Please enable location and try again.", Toast.LENGTH_SHORT).show();
+                                    return;
+                                }
+                                joinWaitingList(eventRecord, dialog, currentLocation);
+                            })
+                            .addOnFailureListener(e ->
+                                    Toast.makeText(this, "Unable to read location. Please try again.", Toast.LENGTH_SHORT).show());
+                })
+                .addOnFailureListener(e ->
+                        Toast.makeText(this, "Unable to read location. Please try again.", Toast.LENGTH_SHORT).show());
+    }
+
+    private boolean hasLocationPermission() {
+        return ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+                || ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private void joinWaitingList(UserEventRecord eventRecord, AlertDialog dialog, Location entrantLocation) {
         updateWaitlistMembership(
                 eventRecord,
                 true,
                 UserEventRecord.STATUS_WAITLISTED,
                 false,
                 "Joined waiting list successfully",
-                dialog
+                dialog,
+                entrantLocation
         );
     }
 
@@ -281,7 +358,8 @@ public class UserEventActivity extends AppCompatActivity {
                 null,
                 true,
                 "Left waiting list",
-                dialog
+                dialog,
+                null
         );
     }
 
@@ -292,7 +370,8 @@ public class UserEventActivity extends AppCompatActivity {
                 UserEventRecord.STATUS_ACCEPTED,
                 false,
                 "Invitation accepted",
-                dialog
+                dialog,
+                null
         );
     }
 
@@ -303,7 +382,8 @@ public class UserEventActivity extends AppCompatActivity {
                 UserEventRecord.STATUS_REJECTED,
                 false,
                 "Invitation declined",
-                dialog
+                dialog,
+                null
         );
     }
 
@@ -312,7 +392,8 @@ public class UserEventActivity extends AppCompatActivity {
                                           String newStatus,
                                           boolean deleteHistory,
                                           String successMessage,
-                                          AlertDialog dialog) {
+                                          AlertDialog dialog,
+                                          Location entrantLocation) {
         DocumentReference eventReference = db.collection("events").document(eventRecord.getEventId());
 
         db.runTransaction(transaction -> {
@@ -333,6 +414,9 @@ public class UserEventActivity extends AppCompatActivity {
             int maxWaitlist = maxWaitlistValue == null ? 0 : maxWaitlistValue.intValue();
 
             if (addEntrant) {
+                if (entrantLocation == null) {
+                    throw new IllegalStateException("Location is required to join this waitlist");
+                }
                 if (waitlistEntrants.contains(entrantId)) {
                     throw new IllegalStateException("You already joined this waiting list");
                 }
@@ -344,9 +428,13 @@ public class UserEventActivity extends AppCompatActivity {
                 waitlistEntrants.remove(entrantId);
             }
 
+            Object locationValue = addEntrant
+                    ? new GeoPoint(entrantLocation.getLatitude(), entrantLocation.getLongitude())
+                    : FieldValue.delete();
             transaction.update(eventReference,
                     "waitlistEntrantIds", waitlistEntrants,
-                    "currentWaitlistCount", waitlistEntrants.size());
+                    "currentWaitlistCount", waitlistEntrants.size(),
+                    "waitlistEntrantLocations." + entrantId, locationValue);
             return waitlistEntrants;
         }).addOnSuccessListener(updatedWaitlist -> {
             eventRecord.setWaitlistEntrantIds(new ArrayList<>(updatedWaitlist));

--- a/app/src/main/java/com/example/wecookproject/UserEventDetailsActivity.java
+++ b/app/src/main/java/com/example/wecookproject/UserEventDetailsActivity.java
@@ -1,6 +1,9 @@
 package com.example.wecookproject;
 
+import android.Manifest;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.location.Location;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.view.View;
@@ -10,12 +13,20 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.core.content.ContextCompat;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.Priority;
+import com.google.android.gms.tasks.CancellationTokenSource;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.GeoPoint;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,6 +40,8 @@ public class UserEventDetailsActivity extends AppCompatActivity {
     private String entrantId;
     private String eventId;
     private UserEventRecord currentEvent;
+    private FusedLocationProviderClient fusedLocationClient;
+    private ActivityResultLauncher<String[]> locationPermissionLauncher;
 
     private TextView tvAvatar;
     private TextView tvHeaderName;
@@ -49,6 +62,19 @@ public class UserEventDetailsActivity extends AppCompatActivity {
 
         entrantId = Settings.Secure.getString(getContentResolver(), Settings.Secure.ANDROID_ID);
         eventId = getIntent().getStringExtra("eventId");
+        fusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
+        locationPermissionLauncher = registerForActivityResult(
+                new ActivityResultContracts.RequestMultiplePermissions(),
+                result -> {
+                    boolean granted = Boolean.TRUE.equals(result.get(Manifest.permission.ACCESS_FINE_LOCATION))
+                            || Boolean.TRUE.equals(result.get(Manifest.permission.ACCESS_COARSE_LOCATION));
+                    if (granted) {
+                        fetchLocationAndJoinWaitlist();
+                    } else {
+                        Toast.makeText(this, "Location permission is required to join the waitlist", Toast.LENGTH_SHORT).show();
+                    }
+                }
+        );
 
         if (eventId == null || eventId.trim().isEmpty()) {
             Toast.makeText(this, "Missing event details", Toast.LENGTH_SHORT).show();
@@ -191,29 +217,75 @@ public class UserEventDetailsActivity extends AppCompatActivity {
         }
 
         btnPrimary.setText("Join the Waitlist");
-        btnPrimary.setOnClickListener(v -> joinWaitlist());
+        btnPrimary.setOnClickListener(v -> requestLocationAndJoinWaitlist());
     }
 
-    private void joinWaitlist() {
-        updateWaitlistMembership(true, UserEventRecord.STATUS_WAITLISTED, false, "Joined waiting list successfully");
+    private void requestLocationAndJoinWaitlist() {
+        if (hasLocationPermission()) {
+            fetchLocationAndJoinWaitlist();
+            return;
+        }
+        locationPermissionLauncher.launch(new String[]{
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+        });
+    }
+
+    private void fetchLocationAndJoinWaitlist() {
+        if (!hasLocationPermission()) {
+            Toast.makeText(this, "Location permission is required to join the waitlist", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        fusedLocationClient.getLastLocation()
+                .addOnSuccessListener(location -> {
+                    if (location != null) {
+                        joinWaitlist(location);
+                        return;
+                    }
+
+                    CancellationTokenSource tokenSource = new CancellationTokenSource();
+                    fusedLocationClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, tokenSource.getToken())
+                            .addOnSuccessListener(currentLocation -> {
+                                if (currentLocation == null) {
+                                    Toast.makeText(this, "Unable to read location. Please enable location and try again.", Toast.LENGTH_SHORT).show();
+                                    return;
+                                }
+                                joinWaitlist(currentLocation);
+                            })
+                            .addOnFailureListener(e ->
+                                    Toast.makeText(this, "Unable to read location. Please try again.", Toast.LENGTH_SHORT).show());
+                })
+                .addOnFailureListener(e ->
+                        Toast.makeText(this, "Unable to read location. Please try again.", Toast.LENGTH_SHORT).show());
+    }
+
+    private boolean hasLocationPermission() {
+        return ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+                || ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private void joinWaitlist(Location entrantLocation) {
+        updateWaitlistMembership(true, UserEventRecord.STATUS_WAITLISTED, false, "Joined waiting list successfully", entrantLocation);
     }
 
     private void leaveWaitlist() {
-        updateWaitlistMembership(false, null, true, "Left waiting list");
+        updateWaitlistMembership(false, null, true, "Left waiting list", null);
     }
 
     private void acceptInvitation() {
-        updateWaitlistMembership(false, UserEventRecord.STATUS_ACCEPTED, false, "Invitation accepted");
+        updateWaitlistMembership(false, UserEventRecord.STATUS_ACCEPTED, false, "Invitation accepted", null);
     }
 
     private void declineInvitation() {
-        updateWaitlistMembership(false, UserEventRecord.STATUS_REJECTED, false, "Invitation declined");
+        updateWaitlistMembership(false, UserEventRecord.STATUS_REJECTED, false, "Invitation declined", null);
     }
 
     private void updateWaitlistMembership(boolean addEntrant,
                                           String newStatus,
                                           boolean deleteHistory,
-                                          String successMessage) {
+                                          String successMessage,
+                                          Location entrantLocation) {
         DocumentReference eventReference = db.collection("events").document(eventId);
 
         db.runTransaction(transaction -> {
@@ -234,6 +306,9 @@ public class UserEventDetailsActivity extends AppCompatActivity {
             int maxWaitlist = maxWaitlistValue == null ? 0 : maxWaitlistValue.intValue();
 
             if (addEntrant) {
+                if (entrantLocation == null) {
+                    throw new IllegalStateException("Location is required to join this waitlist");
+                }
                 if (waitlistEntrants.contains(entrantId)) {
                     throw new IllegalStateException("You already joined this waiting list");
                 }
@@ -245,9 +320,13 @@ public class UserEventDetailsActivity extends AppCompatActivity {
                 waitlistEntrants.remove(entrantId);
             }
 
+            Object locationValue = addEntrant
+                    ? new GeoPoint(entrantLocation.getLatitude(), entrantLocation.getLongitude())
+                    : FieldValue.delete();
             transaction.update(eventReference,
                     "waitlistEntrantIds", waitlistEntrants,
-                    "currentWaitlistCount", waitlistEntrants.size());
+                    "currentWaitlistCount", waitlistEntrants.size(),
+                    "waitlistEntrantLocations." + entrantId, locationValue);
             return waitlistEntrants;
         }).addOnSuccessListener(updatedWaitlist -> {
             currentEvent.setWaitlistEntrantIds(updatedWaitlist);

--- a/app/src/main/res/layout/activity_organizer_event_details.xml
+++ b/app/src/main/res/layout/activity_organizer_event_details.xml
@@ -19,28 +19,6 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <!-- Enable Geolocation toggle -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical"
-                android:layout_marginTop="8dp">
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Enable Geolocation Requirement"
-                    android:textSize="13sp"
-                    android:textColor="@color/text_dark" />
-
-                <com.google.android.material.switchmaterial.SwitchMaterial
-                    android:id="@+id/switch_geolocation"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
-            </LinearLayout>
-
             <!-- Event Header Row -->
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_organizer_event_map.xml
+++ b/app/src/main/res/layout/activity_organizer_event_map.xml
@@ -8,47 +8,14 @@
     android:background="@color/white"
     tools:context=".OrganizerEventMapActivity">
 
-    <!-- Geolocation toggle bar -->
-    <LinearLayout
-        android:id="@+id/ll_geolocation_bar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center_vertical"
-        android:padding="16dp"
-        android:background="@color/white">
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="Enable Geolocation Requirement"
-            android:textSize="13sp"
-            android:textColor="@color/text_dark" />
-
-        <com.google.android.material.switchmaterial.SwitchMaterial
-            android:id="@+id/switch_geolocation"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-    </LinearLayout>
-
-    <!-- Map placeholder (use Maps Fragment in production) -->
-    <FrameLayout
-        android:id="@+id/fl_map_container"
+    <fragment
+        android:id="@+id/map_fragment"
+        android:name="com.google.android.gms.maps.SupportMapFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="56dp"
+        android:layout_marginTop="8dp"
         android:layout_marginBottom="56dp"
-        android:background="@color/bg_light">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:text="Map View"
-            android:textColor="@color/text_muted"
-            android:textSize="16sp" />
-    </FrameLayout>
+        android:background="@color/bg_light" />
 
     <!-- Event header card (overlaid on map, top-left) -->
     <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">wecookproject</string>
     <string name="AdminLogin"> <u>Admin login here.</u> </string>
+    <string name="google_maps_key">AIzaSyDRvcf79E5lm2Q7mwDMCsRGc2avJF8BaXs</string>
 </resources>


### PR DESCRIPTION
This pull request introduces geolocation support for event waitlist registration and map visualization, enhancing both user and organizer flows. The main changes include requesting and handling location permissions, storing entrant geolocations in Firestore, and displaying these locations on a map for organizers. Additionally, dependencies and permissions for location and maps have been added.

**Geolocation & Maps Integration**

* Added dependencies for Google Maps and Location Services in `app/build.gradle.kts`, and required location permissions and API key metadata in `AndroidManifest.xml`. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R50-R51) [[2]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR6-R7) [[3]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR18-R20)
* Implemented the `OrganizerEventMapActivity` to display entrant geolocations on a Google Map, including fetching event and entrant location data from Firestore and handling map initialization and errors. [[1]](diffhunk://#diff-6860fe6bbdb839cba6bdc10237352be2c2140239c36d38e7864132e1da7ddaf8R5-R54) [[2]](diffhunk://#diff-6860fe6bbdb839cba6bdc10237352be2c2140239c36d38e7864132e1da7ddaf8R76-R182)

**User Waitlist Registration Flow**

* Updated `UserEventActivity` to request location permissions, fetch the user's location, and store it in Firestore when joining an event waitlist. This includes permission handling, fallback logic, and integration with the join waitlist dialog. [[1]](diffhunk://#diff-c21878c32d5d95c8efa3a37cc140d341a4e25c084be637b001178b960b05d471R3-R9) [[2]](diffhunk://#diff-c21878c32d5d95c8efa3a37cc140d341a4e25c084be637b001178b960b05d471R21-R24) [[3]](diffhunk://#diff-c21878c32d5d95c8efa3a37cc140d341a4e25c084be637b001178b960b05d471R34-R39) [[4]](diffhunk://#diff-c21878c32d5d95c8efa3a37cc140d341a4e25c084be637b001178b960b05d471R56-R79) [[5]](diffhunk://#diff-c21878c32d5d95c8efa3a37cc140d341a4e25c084be637b001178b960b05d471L263-R350)
* Refactored waitlist and invitation actions to support passing entrant location data, ensuring geolocation is only attached when joining the waitlist. [[1]](diffhunk://#diff-c21878c32d5d95c8efa3a37cc140d341a4e25c084be637b001178b960b05d471L284-R362) [[2]](diffhunk://#diff-c21878c32d5d95c8efa3a37cc140d341a4e25c084be637b001178b960b05d471L295-R374) [[3]](diffhunk://#diff-c21878c32d5d95c8efa3a37cc140d341a4e25c084be637b001178b960b05d471L306-R386)

**Organizer Event Creation & Details**

* Made geolocation mandatory for events in `OrganizerCreateEventActivity` and updated relevant tests to reflect this requirement. [[1]](diffhunk://#diff-4b7a8147743f0525b928e25acb544b89c36d7260b9acaf30126956658801f855L146-R146) [[2]](diffhunk://#diff-51a844766bf4e502bcccc9ebe4df032d2068bfec7221168f98d7380b7230e23eL299-R299)
* Modified `OrganizerEventDetailsActivity` to navigate to the registration map when the map button is clicked, passing the event ID and handling null cases.
* Updated UI tests to verify map navigation and geolocation toggle removal in event details. [[1]](diffhunk://#diff-51a844766bf4e502bcccc9ebe4df032d2068bfec7221168f98d7380b7230e23eL281-R285) [[2]](diffhunk://#diff-51a844766bf4e502bcccc9ebe4df032d2068bfec7221168f98d7380b7230e23eR324-R327)

**Miscellaneous**

* Minor cleanup in test helper comments for clarity.