### PR TITLE
Add role assignment during login process

### DIFF
--- a/app/src/androidTest/java/com/example/wecookproject/UserFlowTest.java
+++ b/app/src/androidTest/java/com/example/wecookproject/UserFlowTest.java
@@ -186,6 +186,7 @@ public class UserFlowTest {
         Map<String, Object> user = new HashMap<>();
         user.put("firstName", "Integration");
         user.put("lastName", "Tester");
+        user.put("role", "entrant");
         user.put("profileCompleted", true);
         db.collection("users").document(androidId).set(user).addOnCompleteListener(t -> latch.countDown());
         try { latch.await(3, TimeUnit.SECONDS); } catch (Exception ignored) {}

--- a/app/src/main/java/com/example/wecookproject/SignupAddressActivity.java
+++ b/app/src/main/java/com/example/wecookproject/SignupAddressActivity.java
@@ -44,6 +44,8 @@ public class SignupAddressActivity extends AppCompatActivity {
             String firstName = intentFromDetails.getStringExtra("firstName");
             String lastName = intentFromDetails.getStringExtra("lastName");
             String birthday = intentFromDetails.getStringExtra("birthday");
+            String clickedRole = intentFromDetails.getStringExtra("clickedRole");
+            String role = "ORGANIZER".equals(clickedRole) ? "organizer" : "entrant";
 
             // Navigate immediately — Firestore write happens in the background
             String androidId = Settings.Secure.getString(getContentResolver(), Settings.Secure.ANDROID_ID);
@@ -57,15 +59,15 @@ public class SignupAddressActivity extends AppCompatActivity {
             userData.put("city", city);
             userData.put("postalCode", postalCode);
             userData.put("country", country);
+            userData.put("role", role);
             userData.put("profileCompleted", true);
 
             FirebaseFirestore db = FirebaseFirestore.getInstance();
             db.collection("users").document(androidId).set(userData)
                 .addOnSuccessListener(aVoid -> {
                     // Go to appropriate Activity only after Firestore success
-                    String role = intentFromDetails.getStringExtra("clickedRole");
                     Intent intent;
-                    if ("ORGANIZER".equals(role)) {
+                    if ("ORGANIZER".equals(clickedRole)) {
                         intent = new Intent(SignupAddressActivity.this, OrganizerHomeActivity.class);
                     } else {
                         intent = new Intent(SignupAddressActivity.this, UserEventActivity.class);


### PR DESCRIPTION
This pull request updates how user roles are handled and stored during the signup process, ensuring the correct role is set in the Firestore database and used for navigation. The changes primarily focus on explicitly assigning and storing the user's role as either "organizer" or "entrant" based on their selection.

**Signup flow improvements:**

* Added logic in `SignupAddressActivity` to determine the user's role (`organizer` or `entrant`) based on the `clickedRole` extra and store it in the `userData` map before writing to Firestore. [[1]](diffhunk://#diff-bb539cfa2149bf27ab4fae78cc8b49251de2cba28982d747fdcdf27b304b9abeR47-R48) [[2]](diffhunk://#diff-bb539cfa2149bf27ab4fae78cc8b49251de2cba28982d747fdcdf27b304b9abeR62-R70)
* Updated navigation logic to use the `clickedRole` extra for deciding which activity to launch after signup.

**Test data consistency:**

* Updated the test user creation in `UserFlowTest.java` to include the `role` field set to "entrant" for consistency with production data.