### PR TITLE
Add smoke-fail androidTest assertion to verify PR blocking

### DIFF
--- a/app/src/androidTest/java/com/example/wecookproject/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/example/wecookproject/ExampleInstrumentedTest.java
@@ -21,6 +21,6 @@ public class ExampleInstrumentedTest {
     public void useAppContext() {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        assertEquals("com.example.wecookproject", appContext.getPackageName());
+        assertEquals("com.example.wecookproject", appContext.getPackageName());`r`n        assertEquals("Intentional smoke failure", 1, 2);
     }
 }


### PR DESCRIPTION
This pull request introduces an intentional test failure in the `ExampleInstrumentedTest` class, likely for smoke testing or to verify test failure reporting.

Test modification:

* Added an assertion that always fails (`assertEquals("Intentional smoke failure", 1, 2)`) to the `useAppContext` test method in `ExampleInstrumentedTest.java`.