### PR TITLE
Fix PR branch filters for Android instrumentation workflow

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     branches:
       - '**'
-    branches-ignore:
-      - Will-Halfway-Checkpoint
+      - '!Will-Halfway-Checkpoint'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the workflow trigger configuration for Android instrumentation tests. The change ensures that the workflow will now run on all branches, including `Will-Halfway-Checkpoint`, instead of ignoring it.