### PR TITLE
Stabilize instrumentation workflow emulator setup

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   android-instrumentation:
     name: connectedDebugAndroidTest
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
 
@@ -36,6 +36,12 @@ jobs:
             exit 1
           fi
           echo "${{ secrets.GOOGLE_SERVICES_JSON_B64 }}" | base64 --decode > app/google-services.json
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Android instrumentation tests to improve compatibility and performance. The main changes involve switching the runner environment from macOS to Ubuntu and adding steps to enable KVM (Kernel-based Virtual Machine) support, which is necessary for running Android emulators efficiently on Linux.

**Workflow environment update:**

* Changed the `runs-on` environment for the `android-instrumentation` job from `macos-latest` to `ubuntu-latest` in `.github/workflows/android-instrumentation-tests.yml`, which should reduce CI costs and enable better support for Android emulators.

**Emulator performance improvements:**

* Added a step to enable KVM on the Ubuntu runner, allowing hardware-accelerated Android emulators for faster and more reliable instrumentation tests.