### PR TITLE
Unify posterUrl usage

### DIFF
--- a/app/src/main/java/com/example/wecookproject/UserHistoryAdapter.java
+++ b/app/src/main/java/com/example/wecookproject/UserHistoryAdapter.java
@@ -75,7 +75,7 @@ public class UserHistoryAdapter extends RecyclerView.Adapter<UserHistoryAdapter.
         holder.tvEventName.setText(item.getEventName());
         holder.tvMeta.setText(item.getLocation() + " • " + UserEventUiUtils.formatDateRange(item.getRegistrationStartDate(), item.getRegistrationEndDate()));
         UserEventUiUtils.applyStatusChip(holder.tvStatus, item.getStatus(), false);
-        PosterLoader.loadInto(holder.ivPoster, item.getPosterUrl());
+        PosterLoader.loadInto(holder.ivPoster, item.getPosterPath());
 
         holder.itemView.setOnClickListener(v -> listener.onHistoryClicked(item));
         holder.btnDelete.setOnClickListener(v -> listener.onDeleteClicked(item));

--- a/app/src/main/java/com/example/wecookproject/UserHistoryItem.java
+++ b/app/src/main/java/com/example/wecookproject/UserHistoryItem.java
@@ -21,7 +21,7 @@ public class UserHistoryItem {
      * @param eventId event identifier
      * @param eventName event name
      * @param location event location label
-     * @param posterPath poster URL/path
+     * @param posterUrl poster URL/path
      * @param status history status
      * @param registrationStartDate registration start timestamp
      * @param registrationEndDate registration end timestamp
@@ -111,7 +111,7 @@ public class UserHistoryItem {
      * @return poster path/url, or {@code null}
      */
     public String getPosterPath() {
-        return posterPath;
+        return posterUrl;
     }
 
     private static String getPosterUrl(com.google.firebase.firestore.DocumentSnapshot snapshot) {

--- a/app/src/main/java/com/example/wecookproject/model/Event.java
+++ b/app/src/main/java/com/example/wecookproject/model/Event.java
@@ -205,14 +205,14 @@ public class Event {
      * @return poster path/url
      */
     public String getPosterPath() {
-        return posterPath;
+        return posterUrl;
     }
 
     /**
      * @param posterPath poster path/url
      */
     public void setPosterPath(String posterPath) {
-        this.posterPath = posterPath;
+        this.posterUrl = posterPath;
     }
 
     /**


### PR DESCRIPTION
This pull request primarily addresses inconsistencies in how poster image URLs/paths are handled across the codebase. The changes standardize the naming and usage of the poster property, ensuring that the correct variable (`posterUrl`) is used throughout the application.

**Poster URL/path standardization:**

* Changed the getter in `UserHistoryItem` and `Event` classes to return the value of `posterUrl` instead of the old `posterPath` variable, ensuring consistent access to the poster's URL/path. [[1]](diffhunk://#diff-6b5cc69e807ca16a2ba359d5ef625367b049a7dcb54369a36de50940be193716L114-R114) [[2]](diffhunk://#diff-b1c27c2e6b5f5b160ab41814e076da25887a75d0e2dfe0e4d51b52d7e1042b48L208-R215)
* Updated the setter in the `Event` class to assign the incoming value to `posterUrl` instead of `posterPath`, maintaining consistency with the new variable name.
* Fixed a parameter name in the documentation of `UserHistoryItem` to refer to `posterUrl` instead of `posterPath`.

**Usage updates:**

* Modified the `UserHistoryAdapter` to use `item.getPosterPath()` (now returning `posterUrl`) when loading posters with `PosterLoader`, aligning with the standardized property.