### PR TITLE
Fix bugs in Admin Flow test

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,6 +73,12 @@
             android:name=".OrganizerEntrantListActivity"
             android:exported="false" />
         <activity
+            android:name=".AdminLoginActivity"
+            android:exported="false" />
+        <activity
+            android:name=".AdminMainActivity"
+            android:exported="false" />
+        <activity
             android:name=".PublicEventLandingActivity"
             android:exported="true">
             <intent-filter>


### PR DESCRIPTION
This pull request updates the Android manifest to register two new activities related to admin functionality. These changes are necessary to enable navigation to admin-specific screens in the app.

**Admin activity registration:**

* Added `AdminLoginActivity` and `AdminMainActivity` as activities in `AndroidManifest.xml`, both set to `android:exported="false"` to restrict access to within the app.